### PR TITLE
Spinning up a snap node on ethereum mainnet on Hyperbolic GPU server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ TWITTER_API_KEY=your-twitter-api-key
 TWITTER_API_SECRET=your-twitter-api-secret
 TWITTER_ACCESS_TOKEN=your-twitter-access-token
 TWITTER_ACCESS_TOKEN_SECRET=your-twitter-access-token-secret
+TWITTER_BEARER_TOKEN=your-twitter-bearer-token
 
 # SSH Configuration
 SSH_PRIVATE_KEY_PATH=~/.ssh/id_rsa 

--- a/chatbot.py
+++ b/chatbot.py
@@ -134,12 +134,12 @@ def initialize_agent():
     config = {"configurable": {"thread_id": "CDP and Hyperbolic Agentkit Chatbot Example!"}}
 
     # Create ReAct Agent using the LLM and all tools.
-    return create_react_agent(
-        llm,
-        tools=tools,
-        checkpointer=memory,
-        state_modifier=
-        """You are a helpful agent that can interact with multiple platforms and services:
+    return (
+        create_react_agent(
+            llm,
+            tools=tools,
+            checkpointer=memory,
+            state_modifier="""You are a helpful agent that can interact with multiple platforms and services:
 
         1. Blockchain Operations (via CDP):
         - Interact onchain via Coinbase Developer Platform
@@ -152,6 +152,7 @@ def initialize_agent():
         - Manage compute infrastructure
         - Connect to remote servers via SSH (use ssh_connect)
         - Execute commands on remote server (use remote_shell)
+        - Spin up an ethereum snap node on remote server
 
         3. System Operations:
         - Use 'ssh_status' to check current SSH connection
@@ -163,7 +164,9 @@ def initialize_agent():
         - Hyperbolic: docs.hyperbolic.xyz
 
         Be concise and helpful. Only describe your tools when explicitly asked.""",
-    ), config
+        ),
+        config,
+    )
 
 
 class CommandTimeout(Exception):

--- a/hyperbolic_agentkit_core/actions/__init__.py
+++ b/hyperbolic_agentkit_core/actions/__init__.py
@@ -4,6 +4,7 @@ from hyperbolic_agentkit_core.actions.get_available_gpus import GetAvailableGpus
 from hyperbolic_agentkit_core.actions.get_gpu_status import GetGpuStatusAction
 from hyperbolic_agentkit_core.actions.ssh_access import SSHAccessAction
 from hyperbolic_agentkit_core.actions.remote_shell import RemoteShellAction
+from hyperbolic_agentkit_core.actions.spin_up_snap_node import SpinUpSnapNodeAction
 
 
 # WARNING: All new HyperbolicAction subclasses must be imported above, otherwise they will not be discovered
@@ -19,6 +20,12 @@ def get_all_hyperbolic_actions() -> list[type[HyperbolicAction]]:
 HYPERBOLIC_ACTIONS = get_all_hyperbolic_actions()
 
 __all__ = [
-    "HYPERBOLIC_ACTIONS", "HyperbolicAction", "RentComputeAction", "GetAvailableGpusAction",
-    "GetGpuStatusAction", "SSHAccessAction", "RemoteShellAction"
+    "HYPERBOLIC_ACTIONS",
+    "HyperbolicAction",
+    "RentComputeAction",
+    "GetAvailableGpusAction",
+    "GetGpuStatusAction",
+    "SSHAccessAction",
+    "RemoteShellAction",
+    "SpinUpSnapNodeAction",
 ]

--- a/hyperbolic_agentkit_core/actions/spin_up_snap_node.py
+++ b/hyperbolic_agentkit_core/actions/spin_up_snap_node.py
@@ -1,0 +1,212 @@
+import os
+import time
+from collections.abc import Callable
+
+from pydantic import BaseModel
+
+from hyperbolic_agentkit_core.actions.hyperbolic_action import HyperbolicAction
+from hyperbolic_agentkit_core.actions.remote_shell import execute_remote_command
+
+
+SPIN_UP_SNAP_NODE_PROMPT = """
+This tool will spin up a snapnode on the ethereum mainnet on Hyperbolic GPU service.
+
+Important notes:
+- A GPU will need to be rented through Hyperbolic platform.
+- A SSH Connection must be connected before running any node. Help the user SSH connect to the GPU they just rented.
+- Provide feedback or errors encountered during each step.
+"""
+
+
+class SpinUpSnapNodeInput(BaseModel):
+    """Input argument schema for spinning up snap node."""
+
+
+def _update_system_install_utilities():
+    try:
+        print(
+            "\nUpdating the system and installing necessary utilities. This step will take some time for the first time running."
+        )
+        commands = [
+            "sudo apt update && sudo apt upgrade -y",
+            "sudo apt install -y curl wget openssl software-properties-common",
+        ]
+        for each in commands:
+            execute_remote_command(each)
+        print("\nSystem updated and installation completed!")
+    except Exception as e:
+        return f"Error during system update and utilities installations: {e.output}"
+
+
+def _install_geth_and_lighthouse():
+    try:
+        print(
+            "\nWe need two clients for spinning up the snap node. Installing Geth and Lighthouse for this."
+        )
+        commands = [
+            "sudo add-apt-repository -y ppa:ethereum/ethereum",
+            "sudo apt update",
+            "sudo apt install -y ethereum",
+            "curl -LO https://github.com/sigp/lighthouse/releases/download/v4.0.1/lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz",
+            "tar -xvf lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz",
+            "sudo cp lighthouse /usr/bin",
+        ]
+        for each in commands:
+            execute_remote_command(each)
+        print("\nGeth and Lighthouse installation completed!")
+    except Exception as e:
+        return f"Error during Geth and Lighthouse installations: {e.output}"
+
+
+def _generate_jwt_secret() -> str:
+    try:
+        print("\nGenerating JWT secret.")
+        secrets_dir = "./.secrets"
+        jwt_path = os.path.join(secrets_dir, "jwt.hex")
+        commands = [
+            f"mkdir -p {secrets_dir}",
+            f"openssl rand -hex 32 | tr -d '\\n' | sudo tee {jwt_path}",
+        ]
+        for each in commands:
+            execute_remote_command(each)
+        print("\nJWT secret generated!")
+        return jwt_path
+    except Exception as e:
+        return f"Error during Geth and Lighthouse installations: {e.output}"
+
+
+def _start_geth(jwt_path: str) -> str:
+    try:
+        print("\nStaring Geth.")
+        data_dir = os.path.expanduser("./.ethereum")
+        log_file = os.path.expanduser("./.ethereum/geth.log")
+        commands = [f"mkdir -p {data_dir}", f"touch {log_file}"]
+        for each in commands:
+            execute_remote_command(each)
+        geth_command = [
+            "nohup",
+            "geth",
+            "--mainnet",
+            "--syncmode",
+            "snap",
+            "--datadir",
+            data_dir,
+            "--http",
+            "--authrpc.addr",
+            "localhost",
+            "--authrpc.vhosts",
+            "localhost",
+            "--authrpc.port",
+            "8551",
+            "--authrpc.jwtsecret",
+            jwt_path,
+            f"> {log_file}",
+            "2>&1 &",
+        ]
+        execute_remote_command(" ".join(geth_command))
+        print("\nGeth is running!")
+        return data_dir
+    except Exception as e:
+        return f"Error during execution layer Geth starting : {e.output}"
+
+
+def _start_lighthouse(jwt_path: str, data_dir: str):
+    try:
+        print("\nStaring Lighthouse.")
+        log_file = os.path.expanduser("./.ethereum/lighthouse.log")
+        execute_remote_command(f"touch {log_file}")
+
+        lighthouse_command = [
+            "nohup",
+            "lighthouse",
+            "beacon_node",
+            "--network",
+            "mainnet",
+            "--http",
+            "--execution-endpoint",
+            "http://localhost:8551",
+            "--datadir",
+            data_dir,
+            "--execution-jwt",
+            jwt_path,
+            f"> {log_file}",
+            "2>&1 &",
+        ]
+        execute_remote_command(" ".join(lighthouse_command))
+        time.sleep(5)  # give it some time before the validation check
+        print("\nLighthouse is running!")
+    except Exception as e:
+        return f"Error during consensus layer Lighthouse starting : {e.output}"
+
+
+def _start_snap_node(jwt_path: str):
+    data_dir = _start_geth(jwt_path)
+    _start_lighthouse(jwt_path, data_dir)
+
+
+def _validate_geth():
+    try:
+        print("\nValidating Geth connection.")
+        curl_command = (
+            "curl -X POST "
+            '-H "Content-Type: application/json" '
+            '--data \'{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}\' '
+            "http://localhost:8545"
+        )
+        response = execute_remote_command(curl_command)
+        if response.startswith("Error:"):
+            _, *output_lines = response.split("\nOutput:", maxsplit=1)
+            if output_lines:
+                print("\nGeth is running and responding properly:", output_lines[0])
+        else:
+            print("\nGeth is running and responding properly:", response)
+    except Exception as e:
+        print(f"Unexpected error during Geth validation: {e}")
+
+
+def _validate_lighthouse():
+    try:
+        print("\nValidating Lighthouse connection.")
+        curl_command = ["curl", "-X", "GET", "http://localhost:5052/eth/v1/node/health"]
+        response = execute_remote_command(" ".join(curl_command))
+        if response.startswith("Error:"):
+            _, *output_lines = response.split("\nOutput:", maxsplit=1)
+            if output_lines:
+                print(
+                    "\nLighthouse is running and responding properly:", output_lines[0]
+                )
+        else:
+            print("\nLighthouse is running and responding properly:", response)
+    except Exception as e:
+        print(f"Unexpected error during Lighthouse validation: {e}")
+
+
+def _validate_connection():
+    _validate_geth()
+    _validate_lighthouse()
+
+
+def spin_up_snap_nodes():
+    # Updating the system and installing necessary utilities
+    _update_system_install_utilities()
+
+    # Installing Geth and Lighthouse
+    _install_geth_and_lighthouse()
+
+    # Generating JWT secret
+    jwt_path = _generate_jwt_secret()
+
+    # Starting Geth and Lighthouse and Verifying the setup
+    _start_snap_node(jwt_path)
+
+    # validate the connection
+    _validate_connection()
+
+
+class SpinUpSnapNodeAction(HyperbolicAction):
+    """Spin up snap node."""
+
+    name: str = "spin_up_snap_node"
+    description: str = SPIN_UP_SNAP_NODE_PROMPT
+    args_schema: type[BaseModel] | None = SpinUpSnapNodeInput
+    func: Callable[..., str] = spin_up_snap_nodes


### PR DESCRIPTION
**_Features:_**

This PR includes the changes for spinning up a snap node on the Ethereum mainnet on one of rented Hyperbolic GPU server.
<img width="1528" alt="Screenshot 2024-12-18 at 10 54 45 AM" src="https://github.com/user-attachments/assets/a15b8bb0-73f4-4572-8576-0328602f6f80" />
The end to end flow is:
1. Will need to rent a GPU first on Hyperbolic platform.
2. Will need to have a SSH connection before running the node.
3. After the SSH connect, the node running will be all automatically. 

The two clients (execution layer + consensus layer) for spinning up a node are using **_Geth_ + _Lighthouse_** by default.


**_Changes_**:
1. Added a new `spin_up_snap_node` files including the changes for all required packages installations and node spinning. Now I have default some variables such as the network is on `mainnet`, the clients are using `Geth + Lighthouse`. We could have more availability later on if we want to make them as input params.
2. Added a missing `TWITTER_BEARER_TOKEN` which will be required for local repo running.
3. Updated a little bit on the `chatbot.py`. Added a prompt language for optional node running function under `Compute Operations (via Hyperbolic)`.
4. Attached the new action under `hyperbolic_agentkit_core/actions/__init__.py`


**_Better to have_**:
1. Add some test cases for the new piece of code.
2. More availability as I mentioned for taking input from user instead of we default the options.
3. More fancy functions such as Validations after the node has been spun up.
